### PR TITLE
Feature/variable snake length

### DIFF
--- a/lib/bs/world/factory.ex
+++ b/lib/bs/world/factory.ex
@@ -5,7 +5,6 @@ alias Bs.World.Factory.Worker
 
 defmodule Bs.World.Factory do
   @timeout 4900
-  @new_snake_length 3
 
   def build(%{id: id} = game) when not is_nil(id) do
     world = %World{
@@ -90,7 +89,7 @@ defmodule Bs.World.Factory do
       for snake <- snakes do
         {:ok, point} = World.rand_unoccupied_space(world)
 
-        coords = List.duplicate(point, @new_snake_length)
+        coords = List.duplicate(point, game.snake_start_length)
 
         put_in(snake.coords, coords)
       end

--- a/lib/bs_repo/game.ex
+++ b/lib/bs_repo/game.ex
@@ -7,6 +7,7 @@ defmodule BsRepo.Game do
     field(:game_mode, :string, default: "multiplayer")
     field(:height, :integer, default: 20)
     field(:max_food, :integer, default: 1)
+    field(:snake_start_length, :integer, default: 3)
     field(:recv_timeout, :integer, default: 200)
     field(:snakes, {:array, :string})
     field(:width, :integer, default: 20)
@@ -14,9 +15,9 @@ defmodule BsRepo.Game do
     timestamps()
   end
 
-  @required [:delay, :game_mode, :height, :max_food, :recv_timeout, :width]
+  @required [:delay, :game_mode, :height, :max_food, :snake_start_length, :recv_timeout, :width]
 
-  @permitted [:delay, :game_mode, :height, :max_food, :recv_timeout, :width]
+  @permitted [:delay, :game_mode, :height, :max_food, :snake_start_length, :recv_timeout, :width]
 
   def changeset(model, params \\ %{}) do
     model
@@ -25,6 +26,7 @@ defmodule BsRepo.Game do
     |> validate_number(:delay, greater_than_or_equal_to: 0)
     |> validate_number(:height, greater_than_or_equal_to: 2)
     |> validate_number(:max_food, greater_than_or_equal_to: 0)
+    |> validate_number(:snake_start_length, greater_than_or_equal_to: 1)
     |> validate_number(:recv_timeout, greater_than_or_equal_to: 0)
     |> validate_number(:width, greater_than_or_equal_to: 2)
     |> validate_required(@required)

--- a/lib/bs_repo/game_form.ex
+++ b/lib/bs_repo/game_form.ex
@@ -17,12 +17,13 @@ defmodule BsRepo.GameForm do
     field(:height, :integer, default: 20)
     field(:delay, :integer, default: 300)
     field(:max_food, :integer, default: 1)
+    field(:snake_start_length, :integer, default: 3)
     field(:game_mode, :string, default: @multiplayer)
     field(:recv_timeout, :integer, default: 200)
   end
 
-  @required [:delay, :game_mode, :height, :max_food, :recv_timeout, :width]
-  @permitted [:delay, :game_mode, :height, :max_food, :recv_timeout, :width]
+  @required  [:delay, :game_mode, :height, :max_food, :snake_start_length, :recv_timeout, :width]
+  @permitted [:delay, :game_mode, :height, :max_food, :snake_start_length, :recv_timeout, :width]
   def changeset(game, params \\ %{}) do
     game
     |> cast(params, @permitted)

--- a/lib/bs_web/templates/game/_form.html.eex
+++ b/lib/bs_web/templates/game/_form.html.eex
@@ -31,6 +31,11 @@
   </div>
 
   <div>
+    <%= label @form, :snake_start_length %>
+    <%= number_input @form, :snake_start_length, required: true %>
+  </div>
+
+  <div>
     <%= label @form, :game_mode %>
     <%= select @form, :game_mode, BsRepo.GameForm.game_modes(), required: true %>
   </div>

--- a/priv/bs_repo/migrations/20180118023100_add_snake_start_length_to_bs_repo_game.exs
+++ b/priv/bs_repo/migrations/20180118023100_add_snake_start_length_to_bs_repo_game.exs
@@ -1,0 +1,9 @@
+defmodule BsRepo.Migrations.AddSnakeStartLengthToBsRepoGame do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bs_repo_game) do
+      add :snake_start_length, :any
+    end
+  end
+end

--- a/priv/bs_repo/migrations/20180118023853_add_snake_start_length_to_game_form.exs
+++ b/priv/bs_repo/migrations/20180118023853_add_snake_start_length_to_game_form.exs
@@ -1,0 +1,9 @@
+defmodule BsRepo.Migrations.AddSnakeStartLengthToGameForm do
+  use Ecto.Migration
+
+  def change do
+    alter table(BsRepo.GameForm) do
+      add :snake_start_length, :any
+    end
+  end
+end

--- a/test/bs_repo/game_test.exs
+++ b/test/bs_repo/game_test.exs
@@ -15,6 +15,7 @@ defmodule Bs.Repo.GameTest do
         game_mode: "singleplayer",
         height: 2,
         max_food: 3,
+        snake_start_length: 5,
         recv_timeout: 4,
         width: 5,
         snakes: ["https://example.com"]
@@ -31,6 +32,7 @@ defmodule Bs.Repo.GameTest do
         game_mode: "sup",
         height: -1,
         max_food: -1,
+        snake_start_length: 0,
         recv_timeout: -1,
         width: -1
       }
@@ -49,6 +51,30 @@ defmodule Bs.Repo.GameTest do
                {
                  "is invalid",
                  [validation: :inclusion]
+               }
+
+      assert changeset.errors[:height] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 2]
+               }
+      
+      assert changeset.errors[:width] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 2]
+               }
+
+      assert changeset.errors[:max_food] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 0]
+               }
+
+      assert changeset.errors[:snake_start_length] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 1]
                }
     end
   end


### PR DESCRIPTION
# Summary

Adds an adjustable _snake_start_length_ parameter, instead of the default length 3.

# Code summary

* two migrations to add _snake_start_length_ to the **games** and **game_form** tables
* updated game specs to check some of the validations
* added _snake start length_ input form
* default length is still 3, but can be adjusted to as low as 1

# Screenshots 

<img width="417" alt="screenshot 2018-01-17 23 32 31" src="https://user-images.githubusercontent.com/3220620/35085986-c31a231c-fbdf-11e7-928e-291abca682b5.png">

<img width="616" alt="screenshot 2018-01-17 23 34 01" src="https://user-images.githubusercontent.com/3220620/35085997-c97af650-fbdf-11e7-8f3a-cfef8e913e8f.png">

# Background and impetus for PR

My team is a sponsor for battlesnake this year and **we're hoping to have a bounty snake challenge that is like tron**, where the tail never moves. I'm sure you know what that is, but to clarify dig this gem: 

![](http://bloonstowerdefense5game.com/datacenter/imgs/tron.jpeg)

**One way to accomplish that is to set the _snake_start_length_ to a really high number.** The rest is just on us to make a decent snake. 

---

Just a personal comment, the code you wrote and the project is really sweet. Really easy to setup and follow. Worked exactly as expected. 
