### PR TITLE
Feature/health lost per turn

### DIFF
--- a/lib/bs/world.ex
+++ b/lib/bs/world.ex
@@ -24,6 +24,7 @@ defmodule Bs.World do
     field(:moves, :any, default: %{}, virtual: true)
     field(:deaths, :any, default: [], virtual: true)
     field(:game_id, :any, default: 0, virtual: true)
+    field(:dec_health_points, :any, default: 1, virtual: true)
   end
 
   @doc """
@@ -93,7 +94,7 @@ defmodule Bs.World do
   @doc "Reduce all snakes health points by 1"
   def dec_health_points(world) do
     update_in(world.snakes, fn snakes ->
-      Enum.map(snakes, &Snake.dec_health_points/1)
+      Enum.map(snakes, &Snake.dec_health_points(&1, world.dec_health_points))
     end)
   end
 

--- a/lib/bs/world/factory.ex
+++ b/lib/bs/world/factory.ex
@@ -14,7 +14,8 @@ defmodule Bs.World.Factory do
       max_food: game.max_food,
       snakes: [],
       width: game.width,
-      game_form_id: id
+      game_form_id: id,
+      dec_health_points: game.dec_health_points
     }
 
     data =

--- a/lib/bs_repo/game.ex
+++ b/lib/bs_repo/game.ex
@@ -11,13 +11,32 @@ defmodule BsRepo.Game do
     field(:recv_timeout, :integer, default: 200)
     field(:snakes, {:array, :string})
     field(:width, :integer, default: 20)
+    field(:dec_health_points, :integer, default: 1)
 
     timestamps()
   end
 
-  @required [:delay, :game_mode, :height, :max_food, :snake_start_length, :recv_timeout, :width]
+  @required [
+    :delay,
+    :game_mode,
+    :height,
+    :max_food,
+    :snake_start_length,
+    :recv_timeout,
+    :width,
+    :dec_health_points
+  ]
 
-  @permitted [:delay, :game_mode, :height, :max_food, :snake_start_length, :recv_timeout, :width]
+  @permitted [
+    :delay,
+    :game_mode,
+    :height,
+    :max_food,
+    :snake_start_length,
+    :recv_timeout,
+    :width,
+    :dec_health_points
+  ]
 
   def changeset(model, params \\ %{}) do
     model
@@ -29,6 +48,7 @@ defmodule BsRepo.Game do
     |> validate_number(:snake_start_length, greater_than_or_equal_to: 1)
     |> validate_number(:recv_timeout, greater_than_or_equal_to: 0)
     |> validate_number(:width, greater_than_or_equal_to: 2)
+    |> validate_number(:dec_health_points, greater_than_or_equal_to: 0)
     |> validate_required(@required)
   end
 end

--- a/lib/bs_repo/game_form.ex
+++ b/lib/bs_repo/game_form.ex
@@ -20,17 +20,43 @@ defmodule BsRepo.GameForm do
     field(:snake_start_length, :integer, default: 3)
     field(:game_mode, :string, default: @multiplayer)
     field(:recv_timeout, :integer, default: 200)
+    field(:dec_health_points, :integer, default: 1)
   end
 
-  @required  [:delay, :game_mode, :height, :max_food, :snake_start_length, :recv_timeout, :width]
-  @permitted [:delay, :game_mode, :height, :max_food, :snake_start_length, :recv_timeout, :width]
+  @required [
+    :delay,
+    :game_mode,
+    :height,
+    :max_food,
+    :snake_start_length,
+    :recv_timeout,
+    :width,
+    :dec_health_points
+  ]
+
+  @permitted [
+    :delay,
+    :game_mode,
+    :height,
+    :max_food,
+    :snake_start_length,
+    :recv_timeout,
+    :width,
+    :dec_health_points
+  ]
+
   def changeset(game, params \\ %{}) do
     game
     |> cast(params, @permitted)
     |> cast_embed(:snakes)
     |> validate_inclusion(:game_mode, @game_modes)
     |> validate_number(:recv_timeout, greater_than_or_equal_to: 0)
+    |> validate_number(:height, greater_than_or_equal_to: 2)
+    |> validate_number(:width, greater_than_or_equal_to: 2)
     |> validate_number(:delay, greater_than_or_equal_to: 0)
+    |> validate_number(:max_food, greater_than_or_equal_to: 0)
+    |> validate_number(:snake_start_length, greater_than_or_equal_to: 1)
+    |> validate_number(:dec_health_points, greater_than_or_equal_to: 0)
     |> validate_required(@required)
     |> remove_empty_snakes()
   end

--- a/lib/bs_web/templates/game/_form.html.eex
+++ b/lib/bs_web/templates/game/_form.html.eex
@@ -36,6 +36,11 @@
   </div>
 
   <div>
+    <%= label @form, "Health lost per turn" %>
+    <%= number_input @form, :dec_health_points, required: true %>
+  </div>
+
+  <div>
     <%= label @form, :game_mode %>
     <%= select @form, :game_mode, BsRepo.GameForm.game_modes(), required: true %>
   </div>

--- a/priv/bs_repo/migrations/20180119021040_add_dec_health_points_to_bs_repo_game.exs
+++ b/priv/bs_repo/migrations/20180119021040_add_dec_health_points_to_bs_repo_game.exs
@@ -1,0 +1,9 @@
+defmodule BsRepo.Migrations.AddDecHealthPointsToBsRepoGame do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bs_repo_game) do
+      add :dec_health_points, :any
+    end
+  end
+end

--- a/priv/bs_repo/migrations/20180119021050_add_dec_health_points_to_game_form.exs
+++ b/priv/bs_repo/migrations/20180119021050_add_dec_health_points_to_game_form.exs
@@ -1,0 +1,9 @@
+defmodule BsRepo.Migrations.AddDecHealthPointsToGameForm do
+  use Ecto.Migration
+
+  def change do
+    alter table(BsRepo.GameForm) do
+      add :dec_health_points, :any
+    end
+  end
+end

--- a/test/bs/world_test.exs
+++ b/test/bs/world_test.exs
@@ -10,9 +10,10 @@ defmodule Bs.WorldTest do
     Map.put(context, :world, world)
   end
 
-  describe "World.dec_health_points/1" do
-    setup do
-      world = build(:world)
+  describe "World.dec_health_points/2" do
+    setup %{world: context_world, dec_health_points: dec} do
+
+      world = %{context_world | dec_health_points: dec}
       snake = build(:snake, health_points: 50)
 
       [snake: _, world: world] =
@@ -25,8 +26,14 @@ defmodule Bs.WorldTest do
       {:ok, snake: snake, world: world}
     end
 
-    test "reduces snake health points by 1", %{snake: snake} do
+    @tag dec_health_points: 1
+    test "reduces snake health points by 1 (default)", %{snake: snake} do
       assert snake.health_points == 49
+    end
+
+    @tag dec_health_points: 2
+    test "reduces snake health points by 2", %{snake: snake} do
+      assert snake.health_points == 48
     end
   end
 

--- a/test/bs_repo/game_form_test.exs
+++ b/test/bs_repo/game_form_test.exs
@@ -2,6 +2,12 @@ defmodule BsRepo.GameFormTest do
   alias BsRepo.GameForm
   use Bs.Case, async: true
 
+  setup do
+    {:atomic, :ok} = :mnesia.clear_table(Elixir.BsRepo.GameForm)
+    {:atomic, :ok} = :mnesia.clear_table(:id_seq)
+    :ok
+  end
+
   test "creating a new record" do
     assert {:ok, _} =
              BsRepo.insert(%GameForm{
@@ -19,6 +25,84 @@ defmodule BsRepo.GameFormTest do
 
     test "returns formatted JSON" do
       assert @expected == @json
+    end
+  end
+
+  describe "changeset" do
+    test "valid changeset" do
+      params = %{
+        delay: 1,
+        game_mode: "singleplayer",
+        height: 2,
+        max_food: 3,
+        snake_start_length: 5,
+        recv_timeout: 4,
+        width: 5,
+        dec_health_points: 0
+      }
+
+      changeset = GameForm.changeset(%GameForm{}, params)
+
+      assert changeset.valid?, inspect(changeset.errors)
+    end
+
+    test "invalid changeset" do
+      params = %{
+        delay: "sup",
+        game_mode: "sup",
+        height: -1,
+        max_food: -1,
+        snake_start_length: 0,
+        recv_timeout: -1,
+        width: -1,
+        dec_health_points: -1
+      }
+
+      changeset = GameForm.changeset(%GameForm{}, params)
+
+      refute changeset.valid?
+
+      assert changeset.errors[:delay] ==
+               {
+                 "is invalid",
+                 [type: :integer, validation: :cast]
+               }
+
+      assert changeset.errors[:game_mode] ==
+               {
+                 "is invalid",
+                 [validation: :inclusion]
+               }
+
+      assert changeset.errors[:height] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 2]
+               }
+      
+      assert changeset.errors[:width] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 2]
+               }
+
+      assert changeset.errors[:max_food] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 0]
+               }
+
+      assert changeset.errors[:snake_start_length] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 1]
+               }
+
+      assert changeset.errors[:dec_health_points] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 0]
+               }
     end
   end
 end

--- a/test/bs_repo/game_test.exs
+++ b/test/bs_repo/game_test.exs
@@ -18,6 +18,7 @@ defmodule Bs.Repo.GameTest do
         snake_start_length: 5,
         recv_timeout: 4,
         width: 5,
+        dec_health_points: 0,
         snakes: ["https://example.com"]
       }
 
@@ -34,7 +35,8 @@ defmodule Bs.Repo.GameTest do
         max_food: -1,
         snake_start_length: 0,
         recv_timeout: -1,
-        width: -1
+        width: -1,
+        dec_health_points: -1
       }
 
       changeset = Game.changeset(%Game{}, params)
@@ -75,6 +77,12 @@ defmodule Bs.Repo.GameTest do
                {
                  "must be greater than or equal to %{number}",
                  [validation: :number, number: 1]
+               }
+
+      assert changeset.errors[:dec_health_points] ==
+               {
+                 "must be greater than or equal to %{number}",
+                 [validation: :number, number: 0]
                }
     end
   end


### PR DESCRIPTION
# Summary

Added a `dec_health_points` field to specify how much health is lost each turn.

* `dec_health_points` default is 1
* `dec_health_points` must be greater than zero
*  extra: matched changeset validations in GameForm to Game
*  extra: copied validation tests in game_test.ex into game_form_test.ex as well (more or less)

# Migrations

Two migrations to add `dec_health_points` to Game and GameForm tables

# Screenshots

<img width="415" alt="screenshot 2018-01-18 21 52 34" src="https://user-images.githubusercontent.com/3220620/35136712-fdc5086e-fc99-11e7-8317-3e8643407955.png">


