### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,9 @@ and Elixir through [kiex](https://github.com/taylor/kiex).
 ```sh
 git clone git@github.com:battle-snake/battle_snake.git`
 cd battle_snake
-yarn install
 mix do local.hex --force, local.rebar
 mix do deps.get, deps.compile
+yarn install
 mix do ecto.create, ecto.migrate
 mix phx.server
 ```


### PR DESCRIPTION
Update local install instructions.

Trying to yarn install prior to installing the elixir deps results in a missing dependency error.